### PR TITLE
fix: reorder columns after delete

### DIFF
--- a/server/routes/columns.js
+++ b/server/routes/columns.js
@@ -6,7 +6,6 @@ const auth = require("../middleware/auth");
 const router = express.Router({ mergeParams: true });
 router.use(auth);
 
-// add column to board
 router.post("/", [body("name").trim().isLength({ min: 1 })], async (req, res) => {
   try {
     const board = await Board.findByPk(req.params.boardId);
@@ -17,21 +16,18 @@ router.post("/", [body("name").trim().isLength({ min: 1 })], async (req, res) =>
   } catch (e) { res.status(500).json({ msg: "error" }); }
 });
 
-// rename column
 router.put("/:colId", async (req, res) => {
   try {
     const col = await Column.findByPk(req.params.colId);
     if (!col) return res.status(404).json({ msg: "not found" });
     if (req.body.name) col.name = req.body.name;
-    await col.save();
-    res.json(col);
+    await col.save(); res.json(col);
   } catch (e) { res.status(500).json({ msg: "error" }); }
 });
 
-// reorder columns
 router.put("/", async (req, res) => {
   try {
-    const { order } = req.body; // [{ id, position }]
+    const { order } = req.body;
     if (!Array.isArray(order)) return res.status(400).json({ msg: "order array required" });
     for (const item of order) {
       await Column.update({ position: item.position }, { where: { id: item.id } });
@@ -40,12 +36,21 @@ router.put("/", async (req, res) => {
   } catch (e) { res.status(500).json({ msg: "error" }); }
 });
 
-// delete column
+// fix: reorder remaining columns after delete to avoid gaps
 router.delete("/:colId", async (req, res) => {
   try {
     const col = await Column.findByPk(req.params.colId);
     if (!col) return res.status(404).json({ msg: "not found" });
+    const boardId = col.boardId;
+    const pos = col.position;
     await col.destroy();
+    // close the gap
+    const remaining = await Column.findAll({ where: { boardId }, order: [["position", "ASC"]] });
+    for (let i = 0; i < remaining.length; i++) {
+      if (remaining[i].position !== i) {
+        await remaining[i].update({ position: i });
+      }
+    }
     res.json({ msg: "deleted" });
   } catch (e) { res.status(500).json({ msg: "error" }); }
 });


### PR DESCRIPTION
when a column is deleted, remaining columns now get their positions normalized to close the gap.

before: delete column at position 1 → positions become [0, 2, 3]
after: delete column at position 1 → positions become [0, 1, 2]

fixes #4